### PR TITLE
Stop resolver and query when no longer needed

### DIFF
--- a/app/src/main/java/com/github/druk/dnssdsamples/DNSSDActivity.java
+++ b/app/src/main/java/com/github/druk/dnssdsamples/DNSSDActivity.java
@@ -145,6 +145,7 @@ public class DNSSDActivity extends AppCompatActivity {
                 public void serviceResolved(DNSSDService resolver, int flags, int ifIndex, String fullName, String hostName, int port, Map<String, String> txtRecord) {
                     Log.d("TAG", "Resolved " + hostName);
                     startQueryRecords(flags, ifIndex, serviceName, regType, domain, hostName, port, txtRecord);
+                    resolver.stop();
                 }
 
                 @Override
@@ -173,6 +174,7 @@ public class DNSSDActivity extends AppCompatActivity {
                                 builder.inet6Address((Inet6Address) address);
                             }
                             mServiceAdapter.add(builder.build());
+                            query.stop();
                         }
                     });
                 }


### PR DESCRIPTION
When using `DNSSDBindable` in my app, I used `DNSSDActivity.java` as a guide.  I found that lots and lots of threads were being created, but never destroyed.  This was leading to performance issues and occasional `OutOfMemoryError` exceptions.

I followed your recommendation [here](https://github.com/andriydruk/RxDNSSD/issues/24#issuecomment-345394256) regarding stopping `resolve` and `query` when no longer needed, and the issue with numerous threads has been fixed.

This pull request updates the example app with this recommendation.