### PR TITLE
Extend the constructors of RxDnssdEmbedded to pass the stoptimedelay attribute

### DIFF
--- a/rx2dnssd/src/main/java/com/github/druk/rx2dnssd/Rx2DnssdEmbedded.java
+++ b/rx2dnssd/src/main/java/com/github/druk/rx2dnssd/Rx2DnssdEmbedded.java
@@ -28,4 +28,8 @@ public class Rx2DnssdEmbedded extends Rx2DnssdCommon {
         super(new DNSSDEmbedded(context));
     }
 
+    public Rx2DnssdEmbedded(Context context, long stopTimeDelay) {
+        super(new DNSSDEmbedded(context, stopTimeDelay));
+    }
+
 }

--- a/rxdnssd/src/main/java/com/github/druk/rxdnssd/RxDnssdEmbedded.java
+++ b/rxdnssd/src/main/java/com/github/druk/rxdnssd/RxDnssdEmbedded.java
@@ -28,4 +28,8 @@ public class RxDnssdEmbedded extends RxDnssdCommon {
         super(new DNSSDEmbedded(context));
     }
 
+    public RxDnssdEmbedded(Context context, long stopTimerDelay) {
+        super(new DNSSDEmbedded(context, stopTimerDelay));
+    }
+
 }


### PR DESCRIPTION
To have the possibility to cancel the service directly after the dispose you should be able to pass the "stopTimeDelay" attribute directly to the constructor.

It is useful to fix rare crashes that occur when an exception is thrown within the timeout. In my case it was because the app forces a Wifi switch immediately after dispose the stream. 