### PR TITLE
🐛 Fix issues where a null service reference could be passed to listeners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ keys/
 *.so
 .externalNativeBuild
 dnssd/.cxx
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ My [explanation](http://andriydruk.com/post/mdnsresponder/) about why jmDNS, And
 
 ## Hierarchy
 
-There are two version of mDNSReposder. 
+There are two version of mDNSReposder.
 
 Bindable version:
 
@@ -43,7 +43,7 @@ Embedded version:
                                 |   +--------------------+   |
                                  -->| Android Java DNSSD |<--
                                     +--------------------+
-                                    |   Apple Java DNSSD |    
+                                    |   Apple Java DNSSD |
                                     +--------------------+
                                     |    mDNS Client     |
                                     +--------------------+
@@ -75,9 +75,9 @@ Rx2DNSSD library:
 compile 'com.github.andriydruk:rx2dnssd:0.9.15'
 ```
 
-* It's built with Andorid NDK 21 for all platforms (1.7 MB). If you prefer another NDK version or subset of platforms, please build it from source with command:
+* It's built with Android NDK 21 for all platforms (1.7 MB). If you prefer another NDK version or subset of platforms, please build it from source with command:
 
-```groovy
+```command
 ./gradlew clean build
 ```
 
@@ -85,28 +85,28 @@ compile 'com.github.andriydruk:rx2dnssd:0.9.15'
 
 ### DNSSD
 
-Dnssd library provides two implementations of DNSSD interface: 
+Dnssd library provides two implementations of DNSSD interface:
 
-DNSSDBindable is an implementation of DNSSD with system's daemon. Use it for Android project with min API higher than 4.1 for an economy of battery consumption (Also some Samsung devices can don't work with this implementation).
+`DNSSDBindable` is an implementation of DNSSD with system's daemon. Use it for Android project with min API higher than 4.1 for an economy of battery consumption (Also some Samsung devices can don't work with this implementation).
 
 ```
-DNSSD dnssd = new DNSSDBindable(context); 
+DNSSD dnssd = new DNSSDBindable(context);
 ```
 
 DNSSDEmbedded is an implementation of RxDnssd with embedded DNS-SD core. Can be used for any Android device with min API higher than Android 4.0.
 
 ```
-DNSSD dnssd = new DNSSDEmbedded(); 
+DNSSD dnssd = new DNSSDEmbedded();
 ```
 
 ##### Register service
 ```java
 try {
-	registerService = dnssd.register("service_name", "_rxdnssd._tcp", 123,  
+	registerService = dnssd.register("service_name", "_rxdnssd._tcp", 123,
    		new RegisterListener() {
 
 			@Override
-			public void serviceRegistered(DNSSDRegistration registration, int flags, 
+			public void serviceRegistered(DNSSDRegistration registration, int flags,
 				String serviceName, String regType, String domain) {
 				Log.i("TAG", "Register successfully ");
 			}
@@ -125,15 +125,15 @@ try {
 ```java
 try {
 	browseService = dnssd.browse("_rxdnssd._tcp", new BrowseListener() {
-                
+
  		@Override
-		public void serviceFound(DNSSDService browser, int flags, int ifIndex, 
+		public void serviceFound(DNSSDService browser, int flags, int ifIndex,
 			final String serviceName, String regType, String domain) {
 			Log.i("TAG", "Found " + serviceName);
 		}
 
 		@Override
-		public void serviceLost(DNSSDService browser, int flags, int ifIndex, 
+		public void serviceLost(DNSSDService browser, int flags, int ifIndex,
 			String serviceName, String regType, String domain) {
 			Log.i("TAG", "Lost " + serviceName);
 		}
@@ -141,7 +141,7 @@ try {
 		@Override
 		public void operationFailed(DNSSDService service, int errorCode) {
 			Log.e("TAG", "error: " + errorCode);
-		}        
+		}
 	});
 } catch (DNSSDException e) {
 	Log.e("TAG", "error", e);
@@ -154,11 +154,11 @@ You can find more samples in app inside this repository.
 
 - RxDnssdBindable
 ```
-RxDnssd rxdnssd = new RxDnssdBindable(context); 
+RxDnssd rxdnssd = new RxDnssdBindable(context);
 ```
 - RxDnssdEmbedded
 ```
-RxDnssd rxdnssd = new RxDnssdEmbedded(); 
+RxDnssd rxdnssd = new RxDnssdEmbedded();
 ```
 
 ##### Register service
@@ -197,11 +197,11 @@ Subscription subscription = rxDnssd.browse("_http._tcp", "local.")
 
 - Rx2DnssdBindable
 ```
-Rx2Dnssd rxdnssd = new Rx2DnssdBindable(context); 
+Rx2Dnssd rxdnssd = new Rx2DnssdBindable(context);
 ```
 - Rx2DnssdEmbedded
 ```
-Rx2Dnssd rxdnssd = new Rx2DnssdEmbedded(); 
+Rx2Dnssd rxdnssd = new Rx2DnssdEmbedded();
 ```
 
 ##### Register service

--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
 # Android mDNSResponder [![Circle CI](https://circleci.com/gh/andriydruk/RxDNSSD.svg?style=shield&circle-token=5f0cb1ee907a20bdb08aa4b073b5690afbaaabe1)](https://circleci.com/gh/andriydruk/RxDNSSD) [![Download](https://img.shields.io/maven-central/v/com.github.andriydruk/dnssd?label=DNSSD)](https://search.maven.org/artifact/com.github.andriydruk/dnssd) [![Download](https://img.shields.io/maven-central/v/com.github.andriydruk/rxdnssd?label=RxDNSSD)](https://search.maven.org/artifact/com.github.andriydruk/rxdnssd) [![Download](https://img.shields.io/maven-central/v/com.github.andriydruk/rx2dnssd?label=Rx2DNSSD) ](https://search.maven.org/artifact/com.github.andriydruk/rx2dnssd)
 
-
-
-
-
 ## Why I created this library?
 My [explanation](http://andriydruk.com/post/mdnsresponder/) about why jmDNS, Android NSD Services and Google Nearby API are not good enough, and why I maintain this library.
 
 ## Hierarchy
 
-There are two version of mDNSReposder.
+There are two versions of mDNSReponder.
 
 Bindable version:
 
@@ -60,19 +56,19 @@ Embedded version:
 DNSSD library:
 
 ```groovy
-compile 'com.github.andriydruk:dnssd:0.9.15'
+compile 'live.ditto:dnssd:0.9.15'
 ```
 
 RxDNSSD library:
 
 ```groovy
-compile 'com.github.andriydruk:rxdnssd:0.9.15'
+compile 'live.ditto:rxdnssd:0.9.15'
 ```
 
 Rx2DNSSD library:
 
-```
-compile 'com.github.andriydruk:rx2dnssd:0.9.15'
+```groovy
+compile 'live.ditto:rx2dnssd:0.9.15'
 ```
 
 * It's built with Android NDK 21 for all platforms (1.7 MB). If you prefer another NDK version or subset of platforms, please build it from source with command:
@@ -89,13 +85,13 @@ Dnssd library provides two implementations of DNSSD interface:
 
 `DNSSDBindable` is an implementation of DNSSD with system's daemon. Use it for Android project with min API higher than 4.1 for an economy of battery consumption (Also some Samsung devices can don't work with this implementation).
 
-```
+```java
 DNSSD dnssd = new DNSSDBindable(context);
 ```
 
 DNSSDEmbedded is an implementation of RxDnssd with embedded DNS-SD core. Can be used for any Android device with min API higher than Android 4.0.
 
-```
+```java
 DNSSD dnssd = new DNSSDEmbedded();
 ```
 
@@ -122,6 +118,7 @@ try {
 ```
 
 ##### Browse services example
+
 ```java
 try {
 	browseService = dnssd.browse("_rxdnssd._tcp", new BrowseListener() {
@@ -162,6 +159,7 @@ RxDnssd rxdnssd = new RxDnssdEmbedded();
 ```
 
 ##### Register service
+
 ```java
 BonjourService bs = new BonjourService.Builder(0, 0, Build.DEVICE, "_rxdnssd._tcp", null).port(123).build();
 Subscription subscription = rxdnssd.register(bonjourService)
@@ -174,6 +172,7 @@ Subscription subscription = rxdnssd.register(bonjourService)
 ```
 
 ##### Browse services example
+
 ```java
 Subscription subscription = rxDnssd.browse("_http._tcp", "local.")
 	.compose(rxDnssd.resolve())
@@ -196,15 +195,17 @@ Subscription subscription = rxDnssd.browse("_http._tcp", "local.")
 ### Rx2DNSSD
 
 - Rx2DnssdBindable
-```
+```java
 Rx2Dnssd rxdnssd = new Rx2DnssdBindable(context);
 ```
+
 - Rx2DnssdEmbedded
-```
+```java
 Rx2Dnssd rxdnssd = new Rx2DnssdEmbedded();
 ```
 
 ##### Register service
+
 ```java
 BonjourService bs = new BonjourService.Builder(0, 0, Build.DEVICE, "_rxdnssd._tcp", null).port(123).build();
 registerDisposable = rxDnssd.register(bs)
@@ -218,6 +219,7 @@ registerDisposable = rxDnssd.register(bs)
 ```
 
 ##### Browse services example
+
 ```java
 browseDisposable = rxDnssd.browse("_http._tcp", "local.")
         .compose(rxDnssd.resolve())

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,7 +26,7 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    ndkVersion "23.1.7779620"
+    ndkVersion "24.0.8215888"
 }
 
 dependencies {

--- a/dnssd/build.gradle
+++ b/dnssd/build.gradle
@@ -34,7 +34,7 @@ android {
         }
     }
 
-    ndkVersion "23.1.7779620"
+    ndkVersion "24.0.8215888"
 }
 
 dependencies {

--- a/dnssd/build.gradle
+++ b/dnssd/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 
 ext {
     // Provide your own coordinates here
-    PUBLISH_GROUP_ID = 'com.github.andriydruk'
+    PUBLISH_GROUP_ID = 'live.ditto'
     PUBLISH_ARTIFACT_ID = 'dnssd'
 }
 

--- a/dnssd/build.gradle
+++ b/dnssd/build.gradle
@@ -56,5 +56,3 @@ ext {
     PUBLISH_GROUP_ID = 'com.github.andriydruk'
     PUBLISH_ARTIFACT_ID = 'dnssd'
 }
-
-apply from: "${rootProject.projectDir}/publish-module.gradle"

--- a/dnssd/build.gradle
+++ b/dnssd/build.gradle
@@ -56,3 +56,7 @@ ext {
     PUBLISH_GROUP_ID = 'com.github.andriydruk'
     PUBLISH_ARTIFACT_ID = 'dnssd'
 }
+
+if (rootProject.name == 'RxDNSSD') {
+    apply from: "${rootProject.projectDir}/publish-module.gradle"
+}

--- a/dnssd/src/main/java/com/github/druk/dnssd/DNSSD.java
+++ b/dnssd/src/main/java/com/github/druk/dnssd/DNSSD.java
@@ -237,8 +237,11 @@ public abstract class DNSSD implements InternalDNSSDService.DnssdServiceListener
                 final Map<String, String> record = parseTXTRecords(txtRecord);
                 handler.removeCallbacks(timeoutRunnable);
                 handler.post(() -> {
-                    listener.serviceResolved(services[0], flags, ifIndex, fullNameStr, hostNameStr, port, record);
-                    services[0].stop();
+                    DNSSDService service = services[0];
+                    if (service != null) {
+                        listener.serviceResolved(service, flags, ifIndex, fullNameStr, hostNameStr, port, record);
+                        service.stop();
+                    }
                 });
             }
 

--- a/dnssd/src/main/java/com/github/druk/dnssd/DNSSD.java
+++ b/dnssd/src/main/java/com/github/druk/dnssd/DNSSD.java
@@ -159,12 +159,17 @@ public abstract class DNSSD implements InternalDNSSDService.DnssdServiceListener
                 final String serviceNameStr = new String(serviceName, UTF_8);
                 final String regTypeStr = new String(regType, UTF_8);
                 final String domainStr = new String(domain, UTF_8);
-                handler.post(() -> listener.serviceLost(services[0], flags, ifIndex, serviceNameStr, regTypeStr, domainStr));
+                handler.post(() -> {
+                    DNSSDService service = services[0];
+                    if (service != null) {
+                        listener.serviceLost(service, flags, ifIndex, serviceNameStr, regTypeStr, domainStr);
+                    }
+                });
             }
 
             @Override
             public void operationFailed(final DNSSDService service, final int errorCode) {
-                handler.post(() -> listener.operationFailed(services[0], errorCode));
+                handler.post(() -> listener.operationFailed(service, errorCode));
             }
         }));
         return services[0];
@@ -233,7 +238,12 @@ public abstract class DNSSD implements InternalDNSSDService.DnssdServiceListener
         onServiceStarting();
         final DNSSDService[] services = new DNSSDService[1];
 
-        final Runnable timeoutRunnable = () -> services[0].stop();
+        final Runnable timeoutRunnable = () -> {
+            DNSSDService service = services[0];
+            if (service != null) {
+                service.stop();
+            }
+        };
 
         services[0] = new InternalDNSSDService(this, InternalDNSSD.resolve(flags, ifIndex, serviceName, regType, domain, new InternalResolveListener() {
             @Override
@@ -255,8 +265,11 @@ public abstract class DNSSD implements InternalDNSSDService.DnssdServiceListener
             public void operationFailed(final DNSSDService service, final int errorCode) {
                 handler.removeCallbacks(timeoutRunnable);
                 handler.post(() -> {
-                    listener.operationFailed(services[0], errorCode);
-                    services[0].stop();
+                    DNSSDService sharedService = services[0];
+                    if (sharedService != null) {
+                        listener.operationFailed(sharedService, errorCode);
+                        sharedService.stop();
+                    }
                 });
             }
         }));
@@ -330,12 +343,22 @@ public abstract class DNSSD implements InternalDNSSDService.DnssdServiceListener
                 final String serviceNameStr =  new String(serviceName, UTF_8);
                 final String regTypeStr = new String(regType, UTF_8);
                 final String domainStr = new String(domain, UTF_8);
-                handler.post(() -> listener.serviceRegistered(services[0], flags, serviceNameStr, regTypeStr, domainStr));
+                handler.post(() -> {
+                    DNSSDRegistration service = services[0];
+                    if (service != null) {
+                        listener.serviceRegistered(service, flags, serviceNameStr, regTypeStr, domainStr);
+                    }
+                });
             }
 
             @Override
             public void operationFailed(DNSSDService service, final int errorCode) {
-                handler.post(() -> listener.operationFailed(services[0], errorCode));
+                handler.post(() -> {
+                    DNSSDService dnsService = services[0];
+                    if (dnsService != null) {
+                        listener.operationFailed(dnsService, errorCode);
+                    }
+                });
             }
         }));
         return services[0];
@@ -454,7 +477,12 @@ public abstract class DNSSD implements InternalDNSSDService.DnssdServiceListener
         onServiceStarting();
         final DNSSDService[] services = new DNSSDService[1];
 
-        final Runnable timeoutRunnable = () -> services[0].stop();
+        final Runnable timeoutRunnable = () -> {
+            DNSSDService service = services[0];
+            if (service != null) {
+                service.stop();
+            }
+        };
 
         services[0] = new InternalDNSSDService(this, InternalDNSSD.queryRecord(flags, ifIndex, serviceName, rrtype, rrclass, new InternalQueryListener() {
             @Override
@@ -462,9 +490,12 @@ public abstract class DNSSD implements InternalDNSSDService.DnssdServiceListener
                 final String fullNameStr = new String(fullName, UTF_8);
                 handler.removeCallbacks(timeoutRunnable);
                 handler.post(() -> {
-                    listener.queryAnswered(services[0], flags, ifIndex, fullNameStr, rrtype, rrclass, rdata, ttl);
-                    if (autoStop) {
-                        services[0].stop();
+                    DNSSDService service = services[0];
+                    if (service != null) {
+                        listener.queryAnswered(service, flags, ifIndex, fullNameStr, rrtype, rrclass, rdata, ttl);
+                        if (autoStop) {
+                            service.stop();
+                        }
                     }
                 });
             }
@@ -473,8 +504,11 @@ public abstract class DNSSD implements InternalDNSSDService.DnssdServiceListener
             public void operationFailed(DNSSDService service, final int errorCode) {
                 handler.removeCallbacks(timeoutRunnable);
                 handler.post(() -> {
-                    listener.operationFailed(services[0], errorCode);
-                    services[0].stop();
+                    DNSSDService sharedService = services[0];
+                    if (sharedService != null) {
+                        listener.operationFailed(sharedService, errorCode);
+                        sharedService.stop();
+                    }
                 });
             }
         }));
@@ -516,18 +550,33 @@ public abstract class DNSSD implements InternalDNSSDService.DnssdServiceListener
             @Override
             public void domainFound(DNSSDService domainEnum, final int flags, final int ifIndex, byte[] domain) {
                 final String domainStr = new String(domain, UTF_8);
-                handler.post(() -> listener.domainFound(services[0], flags, ifIndex, domainStr));
+                handler.post(() -> {
+                    DNSSDService sharedService = services[0];
+                    if (sharedService != null) {
+                        listener.domainFound(sharedService, flags, ifIndex, domainStr);
+                    }
+                });
             }
 
             @Override
             public void domainLost(DNSSDService domainEnum, final int flags, final int ifIndex, byte[] domain) {
                 final String domainStr = new String(domain, UTF_8);
-                handler.post(() -> listener.domainLost(services[0], flags, ifIndex, domainStr));
+                handler.post(() -> {
+                    DNSSDService sharedService = services[0];
+                    if (sharedService != null) {
+                        listener.domainLost(sharedService, flags, ifIndex, domainStr);
+                    }
+                });
             }
 
             @Override
             public void operationFailed(final DNSSDService service, final int errorCode) {
-                handler.post(() -> listener.operationFailed(services[0], errorCode));
+                handler.post(() -> {
+                    DNSSDService sharedService = services[0];
+                    if (sharedService != null) {
+                        listener.operationFailed(sharedService, errorCode);
+                    }
+                });
             }
         }));
         return services[0];

--- a/dnssd/src/main/java/com/github/druk/dnssd/DNSSD.java
+++ b/dnssd/src/main/java/com/github/druk/dnssd/DNSSD.java
@@ -145,7 +145,13 @@ public abstract class DNSSD implements InternalDNSSDService.DnssdServiceListener
                 final String serviceNameStr = new String(serviceName, UTF_8);
                 final String regTypeStr = new String(regType, UTF_8);
                 final String domainStr = new String(domain, UTF_8);
-                handler.post(() -> listener.serviceFound(services[0], flags, ifIndex, serviceNameStr, regTypeStr, domainStr));
+
+                handler.post(() -> {
+                    DNSSDService service = services[0];
+                    if (service != null) {
+                        listener.serviceFound(service, flags, ifIndex, serviceNameStr, regTypeStr, domainStr);
+                    }
+                });
             }
 
             @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,9 @@
 android.enableJetifier = true
 android.useAndroidX = true
 
-mavenCentralVersion = 1.0.0-SNAPSHOT
+group = live.ditto
+version = 1.0.0
+mavenCentralVersion = 1.0.0
 
 # Artifact Signing
 # https://docs.gradle.org/current/userguide/signing_plugin.html#sec:using_gpg_agent

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,11 +10,18 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+# org.gradle.jvmargs = -Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
-android.enableJetifier=true
-android.useAndroidX=true
+# org.gradle.parallel = true
+android.enableJetifier = true
+android.useAndroidX = true
+
+mavenCentralVersion = 1.0.0-SNAPSHOT
+
+# Artifact Signing
+# https://docs.gradle.org/current/userguide/signing_plugin.html#sec:using_gpg_agent
+signing.gnupg.keyName =
+signing.gnupg.passphrase =

--- a/publish-module.gradle
+++ b/publish-module.gradle
@@ -49,8 +49,8 @@ afterEvaluate {
                     developers {
                         developer {
                           id = 'getditto'
-                          name = 'Andrew Druk'
-                          email = 'adriy.druk@gmail.com'
+                          name = 'Ben Chatelain'
+                          email = 'ben@ditto.live'
                         }
                     }
 
@@ -72,5 +72,6 @@ ext["signing.password"] = rootProject.ext["signing.password"]
 ext["signing.secretKeyRingFile"] = rootProject.ext["signing.secretKeyRingFile"]
 
 signing {
+    useGpgCmd()
     sign publishing.publications
 }

--- a/publish-module.gradle
+++ b/publish-module.gradle
@@ -30,7 +30,7 @@ afterEvaluate {
                 if (project.plugins.findPlugin("com.android.library")) {
                     from components.release
                 } else {
-                    artifact("$buildDir/libs/${project.getName()}-${version}.jar")
+                    artifact("$buildDir/libs/${project.name}-${version}.jar")
                 }
 
                 artifact androidSourcesJar
@@ -39,27 +39,27 @@ afterEvaluate {
               pom {
                     name = PUBLISH_ARTIFACT_ID
                     description = 'Android version of Apple DNSSD Java API'
-                    url = 'https://github.com/andriydruk/RxDNSSD'
+                    url = 'https://github.com/getditto/RxDNSSD'
                     licenses {
                         license {
                             name = 'The Apache Software License, Version 2.0'
-                            url = 'https://github.com/andriydruk/RxDNSSD/blob/master/LICENSE'
+                            url = 'https://github.com/getditto/RxDNSSD/blob/master/LICENSE'
                         }
                     }
                     developers {
                         developer {
-                          id = 'andriydruk'
+                          id = 'getditto'
                           name = 'Andrew Druk'
                           email = 'adriy.druk@gmail.com'
                         }
                     }
 
-                // Version control info - if you're using GitHub, follow the 
-                // format as seen here
-                scm {
-                        connection = 'scm:git:github.com/andriydruk/RxDNSSD.git'
-                        developerConnection = 'scm:git:ssh://github.com/andriydruk/RxDNSSD.git'
-                        url = 'https://github.com/andriydruk/RxDNSSD/tree/master'
+                    // Version control info - if you're using GitHub, follow the
+                    // format as seen here
+                    scm {
+                        connection = 'scm:git:github.com/getditto/RxDNSSD.git'
+                        developerConnection = 'scm:git:ssh://github.com/getditto/RxDNSSD.git'
+                        url = 'https://github.com/getditto/RxDNSSD/tree/master'
                     }
                 }
             }

--- a/publish-root.gradle
+++ b/publish-root.gradle
@@ -31,8 +31,8 @@ nexusPublishing {
             stagingProfileId = sonatypeStagingProfileId
             username = ossrhUsername
             password = ossrhPassword
-            //nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            //snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl = uri("https://s01.oss.sonatype.org/service/local/")
+            snapshotRepositoryUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
         }
     }
 }

--- a/rx2dnssd/build.gradle
+++ b/rx2dnssd/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 }
 
 ext {
-    PUBLISH_GROUP_ID = 'com.github.andriydruk'
+    PUBLISH_GROUP_ID = 'live.ditto'
     PUBLISH_ARTIFACT_ID = 'rx2dnssd'
 }
 

--- a/rxdnssd/build.gradle
+++ b/rxdnssd/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 }
 
 ext {
-    PUBLISH_GROUP_ID = 'com.github.andriydruk'
+    PUBLISH_GROUP_ID = 'live.ditto'
     PUBLISH_ARTIFACT_ID = 'rxdnssd'
 }
 

--- a/rxdnssd/build.gradle
+++ b/rxdnssd/build.gradle
@@ -27,7 +27,7 @@ android {
 
 dependencies {
     api project(':dnssd')
-    //api "com.github.andriydruk:dnssd:$mavenCentralVersion"
+    //api "live.ditto:dnssd:$mavenCentralVersion"
 
     // Transitively export that dependencies to other modules
     api 'io.reactivex:rxandroid:1.2.1'


### PR DESCRIPTION
Fixes #215 and #216.

This change prevents passing a `null` service to `BrowseListener.serviceFound()` and `ResolveListener.serviceResolved()` by ensuring the `services` array contains a reference.